### PR TITLE
WIP: Configure Travis to release on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
 language: ruby
+
 rvm:
  - 2.7
  - 2.6
  - 2.5
+
+deploy:
+  provider: rubygems
+  api_key:
+    secure: shhhh
+  gem: money-historical-bank
+  on:
+    tags: true


### PR DESCRIPTION
Note: this is WIP because it does not have a valid token for RubyGems.

The idea here is that if we can configure TravisCI to release this gem, then the friction of releasing new versions is reduced and our lives are made easier. I followed the guide here:

https://docs.travis-ci.com/user/deployment/rubygems/

And even pasted in my API key but then replaced it with what you see here in order to avoid pwning myself. 😝 

So, before merging this I either need to be added to RubyGems so that my token will work, or we'd need @atwam to get his token encrypted and added here. Either would work although I'd be happy to be added so that I could help admin the gem too.