### PR TITLE
Update HistoricalBank to be compatible with ActiveRecord store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
+
+group :test do
+  gem 'rr'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ DEPENDENCIES
   minitest (~> 5, >= 5.0)
   money-historical-bank!
   rake
-  rr (~> 1.0, >= 1.0.4)
+  rr
   rubocop
 
 BUNDLED WITH

--- a/lib/money/rates_store/historical_memory.rb
+++ b/lib/money/rates_store/historical_memory.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'money/rates_store/memory'
+require 'monitor'
+
+class Money
+  module RatesStore
+    # Stores rates in memory for historical queries.
+    # This store is thread-safe.
+    class HistoricalMemory < Money::RatesStore::Memory
+      SERIALIZER_SEPARATOR = '_TO_'
+
+      def initialize(options = {})
+        super
+        @rates = {}
+      end
+
+      # Adds a rate for a given date.
+      #
+      # @param [String] from_currency The currency to exchange from.
+      # @param [String] to_currency The currency to exchange to.
+      # @param [Numeric] rate The exchange rate.
+      # @param [Date] date The date for which the rate is valid.
+      def add_rate(from_currency, to_currency, rate, date)
+        transaction { internal_set_rate(from_currency, to_currency, rate, date) }
+      end
+
+      # Gets all rates for a given date.
+      #
+      # @param [Date] date The date to retrieve rates for.
+      # @return [Hash] A hash of rates for the given date.
+      def get_rates(date)
+        transaction { @rates[date.to_s] }
+      end
+
+      # Iterates over each rate in the store.
+      #
+      # @yield [date, from, to, rate]
+      def each_rate
+        transaction do
+          @rates.each do |date, date_rates|
+            date_rates.each do |key, rate|
+              from, to = key.split(SERIALIZER_SEPARATOR)
+              yield date, from, to, rate
+            end
+          end
+        end
+      end
+
+      private
+
+      def internal_set_rate(from, to, rate, date)
+        return unless Money::Currency.find(from) && Money::Currency.find(to)
+
+        date_rates = @rates[date.to_s] ||= {}
+        date_rates[rate_key_for(from, to)] = rate
+      end
+
+      def rate_key_for(from, to)
+        "#{from}_TO_#{to}".upcase
+      end
+    end
+  end
+end

--- a/test/historical_bank_test.rb
+++ b/test/historical_bank_test.rb
@@ -22,7 +22,7 @@ describe Money::Bank::HistoricalBank do
     it "shouldn't throw an error when internal_set_rate is called with a non existing currency" do
       d1 = Date.new(2011, 1, 1)
       @bank.set_rate(d1, 'BLA', 'ZZZ', 1.01)
-      assert_empty @bank.rates
+      assert_empty @bank.store.instance_variable_get(:@rates)
     end
 
     it 'should return the correct rate interpolated from existing pairs when asked' do


### PR DESCRIPTION
This commit refactors `Money::Bank::HistoricalBank` by introducing `Money::RatesStore::HistoricalMemory` which is a new default store. The `initialize` method now takes a `RateStore` so that an ActiveRecord store can be used.

- `Money::RatesStore::HistoricalMemory` handles thread-safe, in-memory storage of historical exchange rates
- `HistoricalBank` delegates all storage operations to the new rates store
- internal `@rates` hash and `@mutex` have been removed in favor of the store's implementation
- updated tests all pass